### PR TITLE
Add additional tests which cover the PriceCluster fragment (directly …

### DIFF
--- a/src/metering/devices/rainforest/eagle.cpp
+++ b/src/metering/devices/rainforest/eagle.cpp
@@ -197,19 +197,24 @@ void Eagle::ProcessHeaderAttributes(const boost::property_tree::ptree& header_at
 	}
 }
 
-Rainforest::DeviceConnectivity Eagle::Connectivity() const
+const Rainforest::DeviceConnectivity& Eagle::Connectivity() const
 {
 	return m_Connectivity;
 }
 
-Rainforest::DeviceEnergyUsage Eagle::EnergyUsage() const
+const Rainforest::DeviceEnergyUsage& Eagle::EnergyUsage() const
 {
 	return m_EnergyUsage;
 }
 
-Rainforest::DeviceStatistics Eagle::Statistics() const
+const Rainforest::DeviceStatistics& Eagle::Statistics() const
 {
 	return m_Statistics;
+}
+
+const PricingTiers& Eagle::PriceTiers() const
+{
+	return m_PricingTiers;
 }
 
 boost::json::object Eagle::Serialize() const

--- a/src/metering/devices/rainforest/eagle.h
+++ b/src/metering/devices/rainforest/eagle.h
@@ -51,9 +51,9 @@ protected:
 	virtual void ProcessHeaderAttributes(const boost::property_tree::ptree& header_attributes);
 
 public:
-	Rainforest::DeviceConnectivity Connectivity() const;
-	Rainforest::DeviceEnergyUsage EnergyUsage() const;
-	Rainforest::DeviceStatistics Statistics() const;
+	const Rainforest::DeviceConnectivity& Connectivity() const;
+	const Rainforest::DeviceEnergyUsage& EnergyUsage() const;
+	const Rainforest::DeviceStatistics& Statistics() const;
 
 protected:
 	Rainforest::DeviceConnectivity m_Connectivity;
@@ -68,6 +68,9 @@ protected:
 	std::string m_FirmwareVersion;
 	std::string m_HardwareVersion;
 	std::string m_ModelId;
+
+public:
+	const PricingTiers& PriceTiers() const;
 
 protected:
 	PricingTiers m_PricingTiers;

--- a/src/metering/devices/rainforest/messages/partial_message_types/ethernet_mac_id.cpp
+++ b/src/metering/devices/rainforest/messages/partial_message_types/ethernet_mac_id.cpp
@@ -17,7 +17,9 @@ EthernetMacId::EthernetMacId(const std::string& ethernet_mac_id) :
 
 std::size_t EthernetMacId::EthernetMacId_Hasher::operator()(const EthernetMacId& key) const
 {
-	return boost::hash_range(key.DeviceMacId().cbegin(), key.DeviceMacId().cend());
+	auto device_mac_id = key.DeviceMacId();
+
+	return boost::hash_range(device_mac_id.cbegin(), device_mac_id.cend());
 }
 
 std::ostream& operator<<(std::ostream& os, const EthernetMacId& ethernet_macid)

--- a/tests/metering/model/test_eagle_200_model.cpp
+++ b/tests/metering/model/test_eagle_200_model.cpp
@@ -3,6 +3,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <exception>
+#include <stdexcept>
 
 #include "metering/common/unit_converters.h"
 #include "metering/device_registry.h"
@@ -65,6 +66,111 @@ BOOST_AUTO_TEST_CASE(Test_DemandHistory)
 
 		BOOST_TEST(4096 == test_device->EnergyUsage().History[4].second.ValueIn<Watts>());
 		BOOST_TEST(65536 == test_device->EnergyUsage().History[3].second.ValueIn<Watts>());
+	}
+	catch (const std::exception& ex)
+	{
+		BOOST_ERROR(std::string("Unexpected exception while performing test: ") + ex.what());
+	}
+}
+
+BOOST_AUTO_TEST_CASE(Test_TieredPricing, *boost::unit_test::tolerance(0.00001)) // Tolerance is for Pricing testing (floating-point)
+{
+	using namespace test_tools;
+
+	try
+	{
+		auto base_device = DeviceRegistrySingleton()->GetOrCreate<Eagle200>(EthernetMacId("0x75AFD6920098"));
+		auto test_device = std::dynamic_pointer_cast<Eagle200>(base_device);
+
+		{
+			auto raw_payload = test_tools::FragmentGenerator(test_tools::FragmentGenerator::FragmentVersions::V2)
+				.AddFragment_PriceCluster("0x00000001", "0x00000101", "0x0024", "0x00", "0x01", "0x24e50000", "0x0010", "", "Rate 1")
+				.AddFragment_PriceCluster("0x00000002", "0x00000202", "0x0348", "0x01", "0x02", "0x24e60000", "0x0020", "", "Rate 2")
+				.AddFragment_PriceCluster("0x00000003", "0x00000303", "0x03E7", "0x02", "0x03", "0x24e70000", "0x0030", "", "Rate 3")
+				.Generate();
+
+			boost::property_tree::ptree payload;
+			boost::property_tree::read_xml(raw_payload, payload);
+			test_device->ProcessPayload(payload);
+		}
+
+		BOOST_TEST(test_device->PriceTiers().size() == 3);
+		BOOST_CHECK_THROW(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::NotSpecified)).RateLabel(), std::out_of_range);
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_1)).RateLabel() == std::string("Rate 1"));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_1)).Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::AUD));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_1)).Pricing().Price() == 257.0f);
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_2)).RateLabel() == std::string("Rate 2"));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_2)).Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::USD));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_2)).Pricing().Price() == 51.4f);
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_3)).RateLabel() == std::string("Rate 3"));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_3)).Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::XXX));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_3)).Pricing().Price() == 7.71f);
+		BOOST_CHECK_THROW(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_4)).RateLabel(), std::out_of_range);
+		BOOST_CHECK_THROW(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_5)).RateLabel(), std::out_of_range);
+		BOOST_CHECK_THROW(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Unknown)).RateLabel(), std::out_of_range);
+
+		{
+			// NOTE THAT THESE ELEMENTS ARE DELIBERATELY OUT OF ORDER
+
+			auto raw_payload = test_tools::FragmentGenerator(test_tools::FragmentGenerator::FragmentVersions::V2)
+				.AddFragment_PriceCluster("0x00000005", "0x00000505", "0x0024", "0x04", "0x05", "0x24e90000", "0x0050", "", "Rate 5")
+				.AddFragment_PriceCluster("0x00000004", "0x00000404", "0x0348", "0x03", "0x04", "0x24e80000", "0x0040", "", "Rate 4")
+				.Generate();
+
+			boost::property_tree::ptree payload;
+			boost::property_tree::read_xml(raw_payload, payload);
+			test_device->ProcessPayload(payload);
+		}
+
+		BOOST_TEST(test_device->PriceTiers().size() == 5);
+		BOOST_CHECK_THROW(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::NotSpecified)).RateLabel(), std::out_of_range);
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_1)).RateLabel() == std::string("Rate 1"));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_1)).Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::AUD));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_1)).Pricing().Price() == 257.0f);
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_2)).RateLabel() == std::string("Rate 2"));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_2)).Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::USD));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_2)).Pricing().Price() == 51.40f);
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_3)).RateLabel() == std::string("Rate 3"));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_3)).Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::XXX));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_3)).Pricing().Price() == 7.71f);
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_4)).RateLabel() == std::string("Rate 4"));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_4)).Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::USD));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_4)).Pricing().Price() == 1.028f);
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_5)).RateLabel() == std::string("Rate 5"));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_5)).Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::AUD));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_5)).Pricing().Price() == 0.1285f);
+		BOOST_CHECK_THROW(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Unknown)).RateLabel(), std::out_of_range);
+
+		{
+			auto raw_payload = test_tools::FragmentGenerator(test_tools::FragmentGenerator::FragmentVersions::V2)
+				.AddFragment_PriceCluster("0x00000006", "0x00000606", "0x0024", "0x01", "0x01", "0x24e50000", "0x0010", "", "Rate 1 - Updated")
+				.AddFragment_PriceCluster("0x00000007", "0x00000707", "0x0348", "0x01", "0x02", "0x24e60000", "0x0020", "", "Rate 2 - Updated")
+				.AddFragment_PriceCluster("0x00000008", "0x00000808", "0x03E7", "0x01", "0x03", "0x24e70000", "0x0030", "", "Rate 3 - Updated")
+				.Generate();
+
+			boost::property_tree::ptree payload;
+			boost::property_tree::read_xml(raw_payload, payload);
+			test_device->ProcessPayload(payload);
+		}
+
+		BOOST_TEST(test_device->PriceTiers().size() == 5);
+		BOOST_CHECK_THROW(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::NotSpecified)).RateLabel(), std::out_of_range);
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_1)).RateLabel() == std::string("Rate 1 - Updated"));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_1)).Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::AUD));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_1)).Pricing().Price() == 154.2f);
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_2)).RateLabel() == std::string("Rate 2 - Updated"));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_2)).Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::USD));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_2)).Pricing().Price() == 179.9f);
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_3)).RateLabel() == std::string("Rate 3 - Updated"));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_3)).Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::XXX));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_3)).Pricing().Price() == 205.6f);
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_4)).RateLabel() == std::string("Rate 4"));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_4)).Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::USD));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_4)).Pricing().Price() == 1.028f);
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_5)).RateLabel() == std::string("Rate 5"));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_5)).Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::AUD));
+		BOOST_TEST(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Tier_5)).Pricing().Price() == 0.1285f);
+		BOOST_CHECK_THROW(test_device->PriceTiers().at(Tiers(Tiers::SupportedTiers::Unknown)).RateLabel(), std::out_of_range);
 	}
 	catch (const std::exception& ex)
 	{

--- a/tests/metering/rainforest/test_price_cluster.cpp
+++ b/tests/metering/rainforest/test_price_cluster.cpp
@@ -95,4 +95,121 @@ BOOST_AUTO_TEST_CASE(Test_PriceCluster, *boost::unit_test::tolerance(0.00001)) /
 	}
 }
 
+BOOST_AUTO_TEST_CASE(Test_AllPriceTiers, *boost::unit_test::tolerance(0.00001)) // Tolerance is for Pricing testing (floating-point)
+{
+	using namespace test_tools;
+
+	auto v1 = FragmentGenerator(FragmentGenerator::FragmentVersions::V1)
+		.AddFragment_PriceCluster("0x00000001", "0x00000101", "0x0024", "0x00", "0x01", "", "", "Tier 1", "Rate 1")
+		.AddFragment_PriceCluster("0x00000002", "0x00000202", "0x0348", "0x01", "0x02", "", "", "Tier 2", "Rate 2")
+		.AddFragment_PriceCluster("0x00000003", "0x00000303", "0x03E7", "0x02", "0x03", "", "", "Tier 3", "Rate 3")
+		.AddFragment_PriceCluster("0x00000004", "0x00000404", "0x0348", "0x03", "0x04", "", "", "Tier 4", "Rate 4")
+		.AddFragment_PriceCluster("0x00000005", "0x00000505", "0x0024", "0x04", "0x05", "", "", "Tier 5", "Rate 5")
+		.Generate();
+	auto v2 = FragmentGenerator(FragmentGenerator::FragmentVersions::V2)
+		.AddFragment_PriceCluster("0x00000001", "0x00000101", "0x0024", "0x00", "0x01", "0x24e50000", "0x0010", "", "Rate 1")
+		.AddFragment_PriceCluster("0x00000002", "0x00000202", "0x0348", "0x01", "0x02", "0x24e60000", "0x0020", "", "Rate 2")
+		.AddFragment_PriceCluster("0x00000003", "0x00000303", "0x03E7", "0x02", "0x03", "0x24e70000", "0x0030", "", "Rate 3")
+		.AddFragment_PriceCluster("0x00000004", "0x00000404", "0x0348", "0x03", "0x04", "0x24e80000", "0x0040", "", "Rate 4")
+		.AddFragment_PriceCluster("0x00000005", "0x00000505", "0x0024", "0x04", "0x05", "0x24e90000", "0x0050", "", "Rate 5")
+		.Generate();
+
+	boost::property_tree::ptree v1_pricecluster, v2_pricecluster;
+	boost::property_tree::read_xml(v1, v1_pricecluster);
+	boost::property_tree::read_xml(v2, v2_pricecluster);
+
+	try
+	{
+		auto& price_cluster_nodes_v1 = v1_pricecluster.get_child("rainforest");
+		auto pcn_v1_it = price_cluster_nodes_v1.begin();
+
+		++pcn_v1_it; // Skip any <XMLATTR> fields.
+
+		PriceCluster pc_v1_tier1((*pcn_v1_it).second);
+		BOOST_TEST(pc_v1_tier1.DeviceMacId().value() == ZigBeeMacId("0xFFFFFFFFFFFFFFFF"));
+		BOOST_TEST(pc_v1_tier1.TierPricing().Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::AUD));
+		BOOST_TEST(pc_v1_tier1.TierPricing().RateLabel() == std::string("Rate 1"));
+		BOOST_TEST(pc_v1_tier1.Tier() == Tiers(Tiers::SupportedTiers::Tier_1));
+		++pcn_v1_it;
+
+		PriceCluster pc_v1_tier2((*pcn_v1_it).second);
+		BOOST_TEST(pc_v1_tier2.DeviceMacId().value() == ZigBeeMacId("0xFFFFFFFFFFFFFFFF"));
+		BOOST_TEST(pc_v1_tier2.TierPricing().Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::USD));
+		BOOST_TEST(pc_v1_tier2.TierPricing().RateLabel() == std::string("Rate 2"));
+		BOOST_TEST(pc_v1_tier2.Tier() == Tiers(Tiers::SupportedTiers::Tier_2));
+		++pcn_v1_it;
+
+		PriceCluster pc_v1_tier3((*pcn_v1_it).second);
+		BOOST_TEST(pc_v1_tier3.DeviceMacId().value() == ZigBeeMacId("0xFFFFFFFFFFFFFFFF"));
+		BOOST_TEST(pc_v1_tier3.TierPricing().Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::XXX));
+		BOOST_TEST(pc_v1_tier3.TierPricing().RateLabel() == std::string("Rate 3"));
+		BOOST_TEST(pc_v1_tier3.Tier() == Tiers(Tiers::SupportedTiers::Tier_3));
+		++pcn_v1_it;
+
+		PriceCluster pc_v1_tier4((*pcn_v1_it).second);
+		BOOST_TEST(pc_v1_tier4.DeviceMacId().value() == ZigBeeMacId("0xFFFFFFFFFFFFFFFF"));
+		BOOST_TEST(pc_v1_tier4.TierPricing().Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::USD));
+		BOOST_TEST(pc_v1_tier4.TierPricing().RateLabel() == std::string("Rate 4"));
+		BOOST_TEST(pc_v1_tier4.Tier() == Tiers(Tiers::SupportedTiers::Tier_4));
+		++pcn_v1_it;
+
+		PriceCluster pc_v1_tier5((*pcn_v1_it).second);
+		BOOST_TEST(pc_v1_tier5.DeviceMacId().value() == ZigBeeMacId("0xFFFFFFFFFFFFFFFF"));
+		BOOST_TEST(pc_v1_tier5.TierPricing().Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::AUD));
+		BOOST_TEST(pc_v1_tier5.TierPricing().RateLabel() == std::string("Rate 5"));
+		BOOST_TEST(pc_v1_tier5.Tier() == Tiers(Tiers::SupportedTiers::Tier_5));
+		++pcn_v1_it;
+
+		bool no_more_elements_v1 = (price_cluster_nodes_v1.end() == pcn_v1_it);
+		BOOST_TEST(no_more_elements_v1);
+
+		auto& price_cluster_nodes_v2 = v2_pricecluster.get_child("rainforest");
+		auto pcn_v2_it = price_cluster_nodes_v2.begin();
+
+		++pcn_v2_it; // Skip any <XMLATTR> fields.
+
+		PriceCluster pc_v2_tier1((*pcn_v2_it).second);
+		BOOST_TEST(pc_v2_tier1.DeviceMacId().value() == ZigBeeMacId("0xd8d5b9000000fca8"));
+		BOOST_TEST(pc_v2_tier1.TierPricing().Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::AUD));
+		BOOST_TEST(pc_v2_tier1.TierPricing().RateLabel() == std::string("Rate 1"));
+		BOOST_TEST(pc_v2_tier1.Tier() == Tiers(Tiers::SupportedTiers::Tier_1));
+		++pcn_v2_it;
+
+		PriceCluster pc_v2_tier2((*pcn_v2_it).second);
+		BOOST_TEST(pc_v2_tier2.DeviceMacId().value() == ZigBeeMacId("0xd8d5b9000000fca8"));
+		BOOST_TEST(pc_v2_tier2.TierPricing().Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::USD));
+		BOOST_TEST(pc_v2_tier2.TierPricing().RateLabel() == std::string("Rate 2"));
+		BOOST_TEST(pc_v2_tier2.Tier() == Tiers(Tiers::SupportedTiers::Tier_2));
+		++pcn_v2_it;
+
+		PriceCluster pc_v2_tier3((*pcn_v2_it).second);
+		BOOST_TEST(pc_v2_tier3.DeviceMacId().value() == ZigBeeMacId("0xd8d5b9000000fca8"));
+		BOOST_TEST(pc_v2_tier3.TierPricing().Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::XXX));
+		BOOST_TEST(pc_v2_tier3.TierPricing().RateLabel() == std::string("Rate 3"));
+		BOOST_TEST(pc_v2_tier3.Tier() == Tiers(Tiers::SupportedTiers::Tier_3));
+		++pcn_v2_it;
+
+		PriceCluster pc_v2_tier4((*pcn_v2_it).second);
+		BOOST_TEST(pc_v2_tier4.DeviceMacId().value() == ZigBeeMacId("0xd8d5b9000000fca8"));
+		BOOST_TEST(pc_v2_tier4.TierPricing().Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::USD));
+		BOOST_TEST(pc_v2_tier4.TierPricing().RateLabel() == std::string("Rate 4"));
+		BOOST_TEST(pc_v2_tier4.Tier() == Tiers(Tiers::SupportedTiers::Tier_4));
+		++pcn_v2_it;
+
+		PriceCluster pc_v2_tier5((*pcn_v2_it).second);
+		BOOST_TEST(pc_v2_tier5.DeviceMacId().value() == ZigBeeMacId("0xd8d5b9000000fca8"));
+		BOOST_TEST(pc_v2_tier5.TierPricing().Pricing().Currency() == CurrencyCodes(CurrencyCodes::ISO4127_CurrencyCodes::AUD));
+		BOOST_TEST(pc_v2_tier5.TierPricing().RateLabel() == std::string("Rate 5"));
+		BOOST_TEST(pc_v2_tier5.Tier() == Tiers(Tiers::SupportedTiers::Tier_5));
+		++pcn_v2_it;
+
+		bool no_more_elements_v2 = (price_cluster_nodes_v2.end() == pcn_v2_it);
+		BOOST_TEST(no_more_elements_v2);
+	}
+	catch (const std::exception& ex)
+	{
+		BOOST_ERROR(std::string("Unexpected exception while performing test: ") + ex.what());
+	}
+}
+
 BOOST_AUTO_TEST_SUITE_END();

--- a/tests/test_tools/test_tools_fragment_generator.cpp
+++ b/tests/test_tools/test_tools_fragment_generator.cpp
@@ -175,9 +175,14 @@ test_tools::FragmentGenerator& test_tools::FragmentGenerator::AddFragment_Instan
 {
 	switch (m_Version)
 	{
-	case FragmentVersions::V1: AddFragment_InstantaneousDemand("0xFFFFFFFF", "0xFFFFFF", "0xFFFFFFFF", "0xFFFFFFFF"); break;
-	case FragmentVersions::V2: AddFragment_InstantaneousDemand("0x211cc7a8", "0x000032", "0x00000001", "0x000003e8"); break;
-	default: throw std::runtime_error("AddFragment_InstantaneousDemand(): Invalid version present in the FragmentGenerator test tool");
+	case FragmentVersions::V1: 
+		AddFragment_InstantaneousDemand("0xFFFFFFFF", "0xFFFFFF", "0xFFFFFFFF", "0xFFFFFFFF"); 
+		break;
+	case FragmentVersions::V2: 
+		AddFragment_InstantaneousDemand("0x211cc7a8", "0x000032", "0x00000001", "0x000003e8"); 
+		break;
+	default: 
+		throw std::runtime_error("AddFragment_InstantaneousDemand(): Invalid version present in the FragmentGenerator test tool");
 	}
 
 	return *this;
@@ -228,7 +233,7 @@ test_tools::FragmentGenerator& test_tools::FragmentGenerator::AddFragment_Instan
 		break;
 
 	default: 
-		throw std::runtime_error("AddFragment_InstantaneousDemand(): Invalid version present in the FragmentGenerator test tool");
+		throw std::runtime_error("AddFragment_InstantaneousDemand(<params>): Invalid version present in the FragmentGenerator test tool");
 	}
 
 	return *this;
@@ -314,7 +319,8 @@ test_tools::FragmentGenerator& test_tools::FragmentGenerator::AddFragment_PriceC
 		"<TierLabel>{string}</TierLabel>"
 		"<RateLabel>{string}</RateLabel>"
 		"</PriceCluster>";
-	static const std::string V2_PRICE_CLUSTER_FRAGMENT = "<PriceCluster>"
+	static const std::string V2_PRICE_CLUSTER_FRAGMENT = 
+		"<PriceCluster>"
 		"<DeviceMacId>0xd8d5b9000000fca8</DeviceMacId>"
 		"<MeterMacId>0x00078100005a499f</MeterMacId>"
 		"<TimeStamp>0x24e5ffd8</TimeStamp>"
@@ -330,9 +336,66 @@ test_tools::FragmentGenerator& test_tools::FragmentGenerator::AddFragment_PriceC
 
 	switch (m_Version)
 	{
-	case FragmentVersions::V1: m_Fragment.append(V1_PRICE_CLUSTER_FRAGMENT); break;
-	case FragmentVersions::V2: m_Fragment.append(V2_PRICE_CLUSTER_FRAGMENT); break;
-	default: throw std::runtime_error("AddFragment_PriceCluster(): Invalid version present in the FragmentGenerator test tool");
+	case FragmentVersions::V1: 
+		AddFragment_PriceCluster("0xFFFFFFFF", "0x000003E8", "0x03E7", "0x02", "00", "", "", "{string}", "{string}"); 
+		break;		
+	case FragmentVersions::V2: 
+		AddFragment_PriceCluster("0x24e5ffd8", "0x00000005", "0x0348", "0x01", "0x01", "0x24e60010", "0xffff", "", "Price1");
+		break;
+	default: 
+		throw std::runtime_error("AddFragment_PriceCluster(<params>): Invalid version present in the FragmentGenerator test tool");
+	}
+
+	return *this;
+}
+
+test_tools::FragmentGenerator& test_tools::FragmentGenerator::AddFragment_PriceCluster(const std::string& timestamp, const std::string& price, const std::string& currency, const std::string& trailing_digits, const std::string& tier, const std::string& start_time, const std::string& duration, const std::string& tier_label, const std::string& rate_label)
+{
+	static const std::string V1_PRICE_CLUSTER_FRAGMENT_PRE =
+		"<PriceCluster>"
+		"<DeviceMacId>0xFFFFFFFFFFFFFFFF</DeviceMacId>"
+		"<MeterMacId>0xFFFFFFFFFFFFFFFF</MeterMacId>";
+	static const std::string V1_PRICE_CLUSTER_FRAGMENT_POST = 
+		"</PriceCluster>";
+
+	static const std::string V2_PRICE_CLUSTER_FRAGMENT_PRE =
+		"<PriceCluster>"
+		"<DeviceMacId>0xd8d5b9000000fca8</DeviceMacId>"
+		"<MeterMacId>0x00078100005a499f</MeterMacId>"
+		"<TimeStamp>0x24e5ffd8</TimeStamp>";
+	static const std::string V2_PRICE_CLUSTER_FRAGMENT_POST = 
+		"<Protocol>Zigbee</Protocol>"
+		"</PriceCluster>";
+
+	switch (m_Version)
+	{
+	case FragmentVersions::V1:
+		m_Fragment.append(V1_PRICE_CLUSTER_FRAGMENT_PRE);
+		m_Fragment.append("<TimeStamp>").append(timestamp).append("</TimeStamp>");
+		m_Fragment.append("<Price>").append(price).append("</Price>");
+		m_Fragment.append("<Currency>").append(currency).append("</Currency>");
+		m_Fragment.append("<TrailingDigits>").append(trailing_digits).append("</TrailingDigits>");
+		m_Fragment.append("<Tier>").append(tier).append("</Tier>");
+		m_Fragment.append("<TierLabel>").append(tier_label).append("</TierLabel>");
+		m_Fragment.append("<RateLabel>").append(rate_label).append("</RateLabel>");
+		m_Fragment.append(V1_PRICE_CLUSTER_FRAGMENT_POST);
+		break;
+
+	case FragmentVersions::V2:
+		m_Fragment.append(V2_PRICE_CLUSTER_FRAGMENT_PRE);
+		m_Fragment.append("<TimeStamp>").append(timestamp).append("</TimeStamp>");
+		m_Fragment.append("<Price>").append(price).append("</Price>");
+		m_Fragment.append("<Currency>").append(currency).append("</Currency>");
+		m_Fragment.append("<TrailingDigits>").append(trailing_digits).append("</TrailingDigits>");
+		m_Fragment.append("<Tier>").append(tier).append("</Tier>");
+		m_Fragment.append("<StartTime>").append(start_time).append("</StartTime>");
+		m_Fragment.append("<Duration>").append(duration).append("</Duration>");
+		m_Fragment.append("<RateLabel>").append(rate_label).append("</RateLabel>");
+		m_Fragment.append(V2_PRICE_CLUSTER_FRAGMENT_POST);
+		break;
+
+	default:
+		throw std::runtime_error("AddFragment_PriceCluster(): Invalid version present in the FragmentGenerator test tool");
 	}
 
 	return *this;

--- a/tests/test_tools/test_tools_fragment_generator.h
+++ b/tests/test_tools/test_tools_fragment_generator.h
@@ -33,6 +33,7 @@ public:
 	FragmentGenerator& AddFragment_MessageCluster();
 	FragmentGenerator& AddFragment_NetworkInfo();
 	FragmentGenerator& AddFragment_PriceCluster();
+	FragmentGenerator& AddFragment_PriceCluster(const std::string& timestamp, const std::string& price, const std::string& currency, const std::string& trailing_digits, const std::string& tier, const std::string& start_time, const std::string& duration, const std::string& tier_label, const std::string& rate_label);
 
 public:
 	std::stringstream Generate() const;


### PR DESCRIPTION
…and within the eagle data model).

Note that there was two additional changes:
- fix in the EthernetMacId hasher
- passing internal-to-model structs by reference