### PR TITLE
Split out coverage analysis from CI builds

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -10,7 +10,7 @@ env:
   VCPKG_DIR: ${{github.workspace}}/deps/vcpkg
   VCPKG_DEFAULT_TRIPLET: x64-osx
   BUILD_DIR: ${{github.workspace}}/build-macos
-  BUILD_TYPE: Release
+  BUILD_TYPE: RelWithDebInfo
   BUILD_ARCHIVE: binaries-with-build-artefacts.zip
   BINARIES_ARCHIVE: binaries.zip
 
@@ -38,11 +38,6 @@ jobs:
       run: |
         ${{env.VCPKG_DIR}}/bootstrap-vcpkg.sh
         ${{env.VCPKG_DIR}}/vcpkg integrate install
-
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: cpp
 
   #============================================================================
   #
@@ -75,14 +70,20 @@ jobs:
         zip -9 -r -q ${{runner.os}}-${{env.BUILD_ARCHIVE}} ${{env.BUILD_DIR}}/
         zip -9 -r -q ${{runner.os}}-${{env.BINARIES_ARCHIVE}} ${{env.BUILD_DIR}}/eagle-to-mqtt 
 
-    - name: Upload Build Binaries Archive
+    - name: Upload Build Artefacts Archive
       uses: actions/upload-artifact@v2
       if: success()
       with:
         name: ${{runner.os}}-artefacts-buildlogs-testbinaries-and-coveragefiles
-        path: |
-          ${{runner.os}}-${{env.BUILD_ARCHIVE}}
-          ${{runner.os}}-${{env.BINARIES_ARCHIVE}}
+        path: ${{runner.os}}-${{env.BUILD_ARCHIVE}}
+        if-no-files-found: warn 
+
+    - name: Upload Build Binaries Archive
+      uses: actions/upload-artifact@v2
+      if: success()
+      with:
+        name: ${{runner.os}}-binaries
+        path: ${{runner.os}}-${{env.BINARIES_ARCHIVE}}
         if-no-files-found: error
 
   #============================================================================
@@ -93,12 +94,3 @@ jobs:
 
     - name: Run Unit and Integration Tests
       run: ctest -C ${{env.BUILD_TYPE}} --test-dir ${{env.BUILD_DIR}}
-
-  #============================================================================
-  #
-  #  Perform static analysis and upload coverage reports
-  #
-  #============================================================================
-   
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -10,7 +10,7 @@ env:
   VCPKG_DIR: ${{github.workspace}}/deps/vcpkg
   VCPKG_DEFAULT_TRIPLET: x64-windows
   BUILD_DIR: ${{github.workspace}}/build-windows
-  BUILD_TYPE: Release
+  BUILD_TYPE: RelWithDebInfo
   BUILD_ARCHIVE: binaries-with-build-artefacts.zip
   BINARIES_ARCHIVE: binaries.zip
 
@@ -39,11 +39,6 @@ jobs:
         choco install 7zip
         ${{env.VCPKG_DIR}}/bootstrap-vcpkg.bat
         ${{env.VCPKG_DIR}}/vcpkg integrate install
-
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: cpp
 
   #============================================================================
   #
@@ -76,14 +71,20 @@ jobs:
         C:\ProgramData\chocolatey\bin\7z.exe a -tzip ${{runner.os}}-${{env.BUILD_ARCHIVE}} ${{env.BUILD_DIR}} -mx9 -mmt
         C:\ProgramData\chocolatey\bin\7z.exe a -tzip ${{runner.os}}-${{env.BINARIES_ARCHIVE}} ${{env.BUILD_DIR}}/eagle-to-mqtt.exe ${{env.BUILD_DIR}}/*.dll -mx9 -mmt
 
-    - name: Upload Build Binaries Archive
+    - name: Upload Build Artefacts Archive
       uses: actions/upload-artifact@v2
       if: success()
       with:
         name: ${{runner.os}}-artefacts-buildlogs-testbinaries-and-coveragefiles
-        path: |
-          ${{runner.os}}-${{env.BUILD_ARCHIVE}}
-          ${{runner.os}}-${{env.BINARIES_ARCHIVE}}
+        path: ${{runner.os}}-${{env.BUILD_ARCHIVE}}
+        if-no-files-found: warn
+
+    - name: Upload Build Binaries Archive
+      uses: actions/upload-artifact@v2
+      if: success()
+      with:
+        name: ${{runner.os}}-binaries
+        path: ${{runner.os}}-${{env.BINARIES_ARCHIVE}}
         if-no-files-found: error
 
   #============================================================================
@@ -94,12 +95,3 @@ jobs:
 
     - name: Run Unit and Integration Tests
       run: ctest -C ${{env.BUILD_TYPE}} --test-dir ${{env.BUILD_DIR}}
-
-  #============================================================================
-  #
-  #  Perform static analysis and upload coverage reports
-  #
-  #============================================================================
-   
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,4 @@
-name: Build Application (Linux)
+name: CodeQL Analysis (Linux)
 
 on:
   push:
@@ -9,10 +9,8 @@ on:
 env:
   VCPKG_DIR: ${{github.workspace}}/deps/vcpkg
   VCPKG_DEFAULT_TRIPLET: x64-linux
-  BUILD_DIR: ${{github.workspace}}/build-linux
-  BUILD_TYPE: RelWithDebInfo
-  BUILD_ARCHIVE: binaries-with-build-artefacts.zip
-  BINARIES_ARCHIVE: binaries.zip
+  BUILD_DIR: ${{github.workspace}}/build-codeql
+  BUILD_TYPE: Debug
 
 jobs:  
 
@@ -47,60 +45,27 @@ jobs:
         ${{env.VCPKG_DIR}}/bootstrap-vcpkg.sh
         ${{env.VCPKG_DIR}}/vcpkg integrate install
 
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: cpp
+
   #============================================================================
   #
   #  (All Platforms) Build the application
   #
   #============================================================================      
 
-    - name: Cache vcpkg
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-vcpkg-modules
-      with:
-        path: |
-          "${{env.VCPKG_DIR}}/buildtrees"
-          "${{env.VCPKG_DIR}}/downloads"
-          "${{env.VCPKG_DIR}}/packages"
-          "${{env.VCPKG_DIR}}/vcpkg*"
-          "${{env.BUILD_DIR}}/vcpkg_installed"
-        key: ${{runner.os}}-build-${{env.cache-name}}-${{hashFiles('**/vcpkg.json')}}
-        restore-keys: |
-            ${{runner.os}}-build-${{env.cache-name}}-
-            ${{runner.os}}-build-
-            ${{runner.os}}-
-
     - name: Build Application
       run: |
         cmake -S ${{github.workspace}} -B ${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_TOOLCHAIN_FILE=${{env.VCPKG_DIR}}/scripts/buildsystems/vcpkg.cmake
         cmake --build ${{env.BUILD_DIR}} --parallel 4 --config ${{env.BUILD_TYPE}}
 
-    - name: Archive Build Binaries
-      run: |
-        zip -9 -r -q ${{runner.os}}-${{env.BUILD_ARCHIVE}} ${{env.BUILD_DIR}}/
-        zip -9 -r -q ${{runner.os}}-${{env.BINARIES_ARCHIVE}} ${{env.BUILD_DIR}}/eagle-to-mqtt 
-
-    - name: Upload Build Artefacts Archive
-      uses: actions/upload-artifact@v2
-      if: success()
-      with:
-        name: ${{runner.os}}-artefacts-buildlogs-testbinaries-and-coveragefiles
-        path: ${{runner.os}}-${{env.BUILD_ARCHIVE}}
-        if-no-files-found: warn 
-
-    - name: Upload Build Binaries Archive
-      uses: actions/upload-artifact@v2
-      if: success()
-      with:
-        name: ${{runner.os}}-binaries
-        path: ${{runner.os}}-${{env.BINARIES_ARCHIVE}}
-        if-no-files-found: error
-
   #============================================================================
   #
-  #  Run the unit and integration tests
+  #  Perform static analysis
   #
   #============================================================================
-
-    - name: Run Unit and Integration Tests
-      run: ctest -C ${{env.BUILD_TYPE}} --test-dir ${{env.BUILD_DIR}}
+   
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,78 @@
+name: SonarQube Analysis (Linux)
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  VCPKG_DIR: ${{github.workspace}}/deps/vcpkg
+  VCPKG_DEFAULT_TRIPLET: x64-linux
+  BUILD_DIR: ${{github.workspace}}/build-coverage
+  BUILD_TYPE: Debug
+
+jobs:  
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+  #============================================================================
+  #
+  #  Configure any/all pre-requisites
+  #
+  #============================================================================  
+
+    - name: Set up GCC (Linux)
+      uses: egor-tensin/setup-gcc@v1
+      with:
+        version: latest
+        platform: x64
+
+    - name: Install CMake
+      uses: lukka/get-cmake@latest
+
+    - name: Install 3rd Party Dependencies
+      shell: bash
+      run: |
+        # Core dependencies
+        sudo apt-get install -y --no-install-recommends curl gcovr libicu66 libssl1.1 libssl-dev make pkg-config unzip
+        ${{env.VCPKG_DIR}}/bootstrap-vcpkg.sh
+        ${{env.VCPKG_DIR}}/vcpkg integrate install
+        # SonarQube scanner
+        wget -nv https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.6.2.2472-linux.zip
+        unzip -q sonar-scanner-cli-4.6.2.2472-linux.zip
+        echo "${PWD}/sonar-scanner-4.6.2.2472-linux/bin/" >> $GITHUB_PATH
+        # SonarQube build wrapper
+        wget -nv https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip
+        unzip -q build-wrapper-linux-x86.zip
+        echo "${PWD}/build-wrapper-linux-x86" >> $GITHUB_PATH
+
+  #============================================================================
+  #
+  #  (All Platforms) Build the application
+  #
+  #============================================================================      
+
+    - name: Build Application
+      run: |
+        cmake -S ${{github.workspace}} -B ${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_TOOLCHAIN_FILE=${{env.VCPKG_DIR}}/scripts/buildsystems/vcpkg.cmake -DE2M_OPTION_CODE_COVERAGE=ON -DE2M_OPTION_SUPPORT_SONARQUBE=ON
+        build-wrapper-linux-x86-64 --out-dir ${{env.BUILD_DIR}}/bw-output cmake --build ${{env.BUILD_DIR}} --parallel 4 --config ${{env.BUILD_TYPE}} --target coverage
+
+  #============================================================================
+  #
+  #  Perform static analysis and upload coverage reports
+  #
+  #============================================================================
+  
+    - name: Perform SonarCloud Analysis
+      env: 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: |
+        sonar-scanner -Dsonar.login="$SONAR_TOKEN" -Dsonar.cfamily.build-wrapper-output=${{env.BUILD_DIR}}/bw-output -Dsonar.coverageReportPaths=${{env.BUILD_DIR}}/coverage.sonarqube.xml -X


### PR DESCRIPTION
* Update all the CI builds to produce "RelWithDebInfo" artefacts (storing them separately).
* Split out coverage (SonarQube) from the CI builds.
* Split out the CodeQL analysis from the CI builds